### PR TITLE
Feature: Displayname for ProjectPermissions

### DIFF
--- a/aruna/api/storage/models/v1/auth.proto
+++ b/aruna/api/storage/models/v1/auth.proto
@@ -78,4 +78,5 @@ message ProjectPermission {
   string user_id = 1;
   string project_id = 2;
   Permission permission = 3;
+  string display_name = 4;
 }


### PR DESCRIPTION
This is a small feature that introduces the displayname of an user to the project permissions.
It enables users to see a specific "username" for their projects instead of the anonymous user uuid.
Internally the user-id is still the only source of truth and this will not change since every user can change its displayname
at any time and these names are NOT unique.

Please don´t write any code that relies on display_names.