### PR TITLE
V0.5.0 beta.9

### DIFF
--- a/aruna/api/storage/models/v1/auth.proto
+++ b/aruna/api/storage/models/v1/auth.proto
@@ -78,6 +78,7 @@ message ProjectPermission {
   string user_id = 1;
   string project_id = 2;
   Permission permission = 3;
+  bool service_account = 4;
 }
 
 message ProjectPermissionDisplayName {

--- a/aruna/api/storage/services/v1/info_service.proto
+++ b/aruna/api/storage/services/v1/info_service.proto
@@ -61,9 +61,8 @@ service StorageInfoService {
 
 
 message GetResourceHierarchyRequest {
-    string project_id = 1;
-    string resource_id = 2;
-    storage.models.v1.ResourceType resource_type = 3;
+    string resource_id = 1;
+    storage.models.v1.ResourceType resource_type = 2;
 }
 
 message Hierarchy {

--- a/aruna/api/storage/services/v1/service_account_service.proto
+++ b/aruna/api/storage/services/v1/service_account_service.proto
@@ -1,0 +1,206 @@
+syntax = "proto3";
+
+package aruna.api.storage.services.v1;
+option go_package = "github.com/ArunaStorage/go-api/aruna/api/storage/services/v1";
+option java_multiple_files = true;
+option java_package = "com.github.ArunaStorage.java_api.aruna.api.storage.services.v1";
+option java_outer_classname = "ServiceAccountService";
+
+import "aruna/api/storage/models/v1/auth.proto";
+
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+
+
+// ServiceAccountService
+//
+// Service that contains all methods for service_accounts, these are Accounts that are
+// project specific (or global) and can be used for automation. 
+// Service account users will always contain (bot) behind their name
+service ServiceAccountService {
+
+  // CreateServiceAccount
+  //
+  // Creates a service account for a given project
+  // If the service account has permissions for the global Admin project
+  // it will be a global service account that can interact with any resource
+  rpc CreateServiceAccount(CreateServiceAccountRequest) returns (CreateServiceAccountResponse){
+    option (google.api.http) = {
+      post : "/v1/service_account"
+      body : "*"
+    };
+  }
+  
+  // CreateServiceAccountToken
+  //
+  // Creates a token for a service account
+  // Each service account can only have one permission -> The token will have the same permission as the
+  // service account
+  rpc CreateServiceAccountToken(CreateServiceAccountTokenRequest) returns (CreateServiceAccountTokenResponse){
+    option (google.api.http) = {
+      post : "/v1/service_account/{svc_account_id}/token"
+      body : "*"
+    };
+  }
+  
+  // EditServiceAccountPermission
+  //
+  // Overwrites the project specific permissions for a service account
+  rpc EditServiceAccountPermission(EditServiceAccountPermissionRequest) returns (EditServiceAccountPermissionResponse){
+    option (google.api.http) = {
+      put : "/v1/service_account/{svc_account_id}/permissions"
+      body : "*"
+    };
+  }
+ 
+  // GetServiceAccountToken
+  //
+  // This requests the overall information about a specifc service account token (by id)
+  // it will not contain the token itself.
+  rpc GetServiceAccountToken(GetServiceAccountTokenRequest) returns (GetServiceAccountTokenResponse){
+    option (google.api.http) = {
+      get : "/v1/service_account/{svc_account_id}/token/{token_id}"
+    };
+  }
+
+  // GetServiceAccountTokens
+  //
+  // This requests the overall information about all service account tokens
+  // it will not contain the token itself.
+  rpc GetServiceAccountTokens(GetServiceAccountTokensRequest) returns (GetServiceAccountTokensResponse){
+    option (google.api.http) = {
+      get : "/v1/service_account/{svc_account_id}/tokens"
+    };
+  }
+
+  // GetServiceAccountsByProject
+  //
+  // Will request all service_accounts for a given project
+  // each service account is bound to a specific project
+  rpc GetServiceAccountsByProject(GetServiceAccountsByProjectRequest) returns (GetServiceAccountsByProjectResponse){
+    option (google.api.http) = {
+      get : "/v1/service_account/project/{project_id}"
+    };
+  }
+
+  // DeleteServiceAccountToken
+  // 
+  // Deletes one service account token by ID
+  rpc DeleteServiceAccountToken(DeleteServiceAccountTokenRequest) returns (DeleteServiceAccountTokenResponse){
+    option (google.api.http) = {
+      delete : "/v1/service_account/{svc_account_id}/token/{token_id}"
+    };
+  }
+  
+  // DeleteServiceAccountTokens
+  // 
+  // Deletes all service account tokens
+  rpc DeleteServiceAccountTokens(DeleteServiceAccountTokensRequest) returns (DeleteServiceAccountTokensResponse){
+    option (google.api.http) = {
+      delete : "/v1/service_account/{svc_account_id}/tokens"
+    };
+  }
+  
+  // DeleteServiceAccount
+  // 
+  // Deletes a service account (by id)
+  rpc DeleteServiceAccount(DeleteServiceAccountRequest) returns (DeleteServiceAccountResponse){
+    option (google.api.http) = {
+      delete : "/v1/service_account/{svc_account_id}"
+    };
+  }
+}
+
+
+message CreateServiceAccountRequest {
+    string name = 1;
+    string project_id = 2;
+    storage.models.v1.Permission permission = 3;
+}
+
+message ServiceAccount {
+    string svc_account_id = 1;
+    string project_id = 2;
+    string name = 3;
+    storage.models.v1.Permission permission = 4;
+}
+
+message CreateServiceAccountResponse {
+    ServiceAccount service_account = 1;
+}
+
+message CreateServiceAccountTokenRequest {
+    // Empty if token should inherit account / project permissions
+    // Collection id
+    string collection_id = 1;
+    // Token name
+    string name = 2;
+    // Token expiry
+    google.protobuf.Timestamp expires_at = 3;
+    // Token permissions
+    storage.models.v1.Permission permission = 4;
+}
+
+message CreateServiceAccountTokenResponse {
+    // This contains only the token description
+    storage.models.v1.Token token = 1;
+    // This is the actual secret token
+    // Attention, this can not be recreated and needs to be stored securely
+    // New tokens will always contain a new secret
+    string token_secret = 2;
+}
+
+message EditServiceAccountPermissionRequest {
+    string svc_account_id = 1;
+    storage.models.v1.Permission new_permission = 2;
+}
+
+message EditServiceAccountPermissionResponse {
+    ServiceAccount service_account = 1;
+}
+
+message GetServiceAccountTokenRequest {
+    string svc_account_id = 1;
+    string token_id = 2;
+}
+
+message GetServiceAccountTokenResponse {
+    // This contains only the token description
+    storage.models.v1.Token token = 1;
+}
+
+message GetServiceAccountTokensRequest {
+    string svc_account_id = 1;
+}
+
+message GetServiceAccountTokensResponse {
+    // This contains only the token description
+    repeated storage.models.v1.Token token = 1;
+}
+
+message GetServiceAccountsByProjectRequest {
+    string project_id = 1;
+}
+
+message GetServiceAccountsByProjectResponse {
+    repeated ServiceAccount svc_accounts = 1;
+}
+
+message DeleteServiceAccountTokenRequest {
+    string svc_account_id = 1;
+    string token_id = 2;
+}
+
+message DeleteServiceAccountTokenResponse {}
+
+message DeleteServiceAccountTokensRequest {
+    string svc_account_id = 1;
+}
+
+message DeleteServiceAccountTokensResponse {}
+
+message DeleteServiceAccountRequest {
+    string svc_account_id = 1;
+}
+
+message DeleteServiceAccountResponse {}


### PR DESCRIPTION
# Overview

A minor update to existing functionalities and the addition of a service account service.

## Changes
1. Removed project_id from get_resource_hierarchy request, this will allow users to query a full hierarchy just by resource id without the need for a project_id
2. Added separate service for service accounts (Refers to ArunaStorage/ArunaServer#38):
Service accounts are special project bound accounts that can be managed by all project admins. They are used to authorize and manage project specific automations. 

## BREAKING CHANGES:
 - (1.) Breaks the old specification for the hierarchy request
 - (2.) Adds an additional boolean field to ProjectPermissions that indicates if a project user associations refers to a service account.  This is only used in responses and should not break existing implementations but might break strongly typed ones that require all fields in advance.