### PR TITLE
[1.0.0-rc.5] Final preparations for 1.0.0

### DIFF
--- a/aruna/api/internal/v1/authorize.proto
+++ b/aruna/api/internal/v1/authorize.proto
@@ -22,7 +22,7 @@ message Authorization {
 
 enum IdType {
     ID_TYPE_UNSPECIFIED = 0;
-    ID_TYPE_OBJECT = 1;
+    ID_TYPE_UUID = 1;
     ID_TYPE_PATH = 2;
 }
 
@@ -38,6 +38,8 @@ message AuthorizeRequest{
     Identifier identifier = 2; 
     // Which action should be performed (CRUD)
     aruna.api.storage.models.v1.ResourceAction resource_action = 3;
+    // Authorization
+    Authorization authorization = 4;
 }
 
 message AuthorizeResponse {

--- a/aruna/api/internal/v1/authorize.proto
+++ b/aruna/api/internal/v1/authorize.proto
@@ -20,11 +20,22 @@ message Authorization {
     bool is_token = 3;
 }
 
+enum IdType {
+    ID_TYPE_UNSPECIFIED = 0;
+    ID_TYPE_OBJECT = 1;
+    ID_TYPE_PATH = 2;
+}
+
+message Identifier {
+    string name = 1;
+    IdType idtype = 2;
+}
+
 message AuthorizeRequest{
     // The resource type
     aruna.api.storage.models.v1.ResourceType resource = 1;
-    // Id of the resource
-    string resource_id = 2;
+    // Id of the resource (PATH / OBJECT UUID)
+    Identifier identifier = 2; 
     // Which action should be performed (CRUD)
     aruna.api.storage.models.v1.ResourceAction resource_action = 3;
 }

--- a/aruna/api/internal/v1/proxy.proto
+++ b/aruna/api/internal/v1/proxy.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package aruna.api.internal.v1;
 option go_package = "github.com/ArunaStorage/go-api/aruna/api/internal/v1";
+import "aruna/api/storage/models/v1/models.proto";
+import "aruna/api/internal/v1/authorize.proto";
 import "google/api/visibility.proto";
 
 // Definition for the internal API that is used to communicate with all internal
@@ -30,13 +32,12 @@ service InternalProxyService {
   rpc MoveObject(MoveObjectRequest) returns (MoveObjectResponse) {}
 }
 
-
 // This service enables a "return" channel for dataproxy to aruna server communication
 // Mainly used to notify the backend of validation / move events after the upload of new files
 service InternalProxyNotifierService {
   option (google.api.api_visibility).restriction = "INTERNAL";
-  rpc ValidatedObject(ValidatedObjectRequest) returns (ValidatedObjectResponse) {}
-
+  rpc FinalizeObject(FinalizeObjectRequest) returns (FinalizeObjectResponse) {}
+  rpc GetEncryptionKey(GetEncryptionKeyRequest) returns (GetEncryptionKeyResponse) {}
 }
 
 // Enum to support multiple target Locations.
@@ -128,3 +129,19 @@ message MoveObjectRequest {
 }
 
 message MoveObjectResponse {}
+
+message FinalizeObjectRequest {
+  string object_id = 1;
+  Location final_location = 2;
+  repeated aruna.api.storage.models.v1.Hash hashes = 3;
+}
+
+message FinalizeObjectResponse {}
+
+message GetEncryptionKeyRequest {
+  Identifier identifier = 1;
+}
+
+message GetEncryptionKeyResponse {
+  string encryption_key = 1;
+}

--- a/aruna/api/internal/v1/proxy.proto
+++ b/aruna/api/internal/v1/proxy.proto
@@ -131,9 +131,8 @@ message MoveObjectRequest {
 message MoveObjectResponse {}
 
 message FinalizeObjectRequest {
-  string object_id = 1;
-  Location final_location = 2;
-  repeated aruna.api.storage.models.v1.Hash hashes = 3;
+  Location final_location = 1;
+  repeated aruna.api.storage.models.v1.Hash hashes = 2;
 }
 
 message FinalizeObjectResponse {}

--- a/aruna/api/internal/v1/proxy.proto
+++ b/aruna/api/internal/v1/proxy.proto
@@ -131,8 +131,9 @@ message MoveObjectRequest {
 message MoveObjectResponse {}
 
 message FinalizeObjectRequest {
-  Location final_location = 1;
-  repeated aruna.api.storage.models.v1.Hash hashes = 2;
+  Location before_location = 1;
+  Location final_location = 2;
+  repeated aruna.api.storage.models.v1.Hash hashes = 3;
 }
 
 message FinalizeObjectResponse {}

--- a/aruna/api/internal/v1/proxy.proto
+++ b/aruna/api/internal/v1/proxy.proto
@@ -26,6 +26,17 @@ service InternalProxyService {
   rpc CreatePresignedDownload(CreatePresignedDownloadRequest)
       returns (CreatePresignedDownloadResponse) {}
   rpc CreateBucket(CreateBucketRequest) returns (CreateBucketResponse) {}
+  rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse) {}
+  rpc MoveObject(MoveObjectRequest) returns (MoveObjectResponse) {}
+}
+
+
+// This service enables a "return" channel for dataproxy to aruna server communication
+// Mainly used to notify the backend of validation / move events after the upload of new files
+service InternalProxyNotifierService {
+  option (google.api.api_visibility).restriction = "INTERNAL";
+  rpc ValidatedObject(ValidatedObjectRequest) returns (ValidatedObjectResponse) {}
+
 }
 
 // Enum to support multiple target Locations.
@@ -104,3 +115,16 @@ message CreatePresignedDownloadResponse {
 message CreateBucketRequest { string bucket_name = 1; }
 
 message CreateBucketResponse {}
+
+message DeleteObjectRequest {
+  Location location = 1;
+}
+
+message DeleteObjectResponse {}
+
+message MoveObjectRequest {
+  Location from = 1;
+  Location to = 2;
+}
+
+message MoveObjectResponse {}

--- a/aruna/api/storage/services/v1/object_service.proto
+++ b/aruna/api/storage/services/v1/object_service.proto
@@ -325,7 +325,7 @@ service ObjectService {
   // !! Paths are collection specific !!
   rpc SetObjectPathVisibility(SetObjectPathVisibilityRequest) returns (SetObjectPathVisibilityResponse) {
     option (google.api.http) = {
-      patch : "/v1/collection/{collection_id}/object/{object_id}/path/{path}/visibility"
+      patch : "/v1/collection/{collection_id}/path/{path}/visibility"
       body: "*"
     };
   }


### PR DESCRIPTION
This is intended to be the last update to the API before 1.0.0. It should include no changes to the user-facing API (except the update of the OpenAPI path for `SetObjectPathVisibility`).

Full changelog:

- Removed the `object_id` part from the openapi path anotation in `SetObjectPathVisibility`
- Internal: Updated internal `authorize` method to properly handle paths and resource ids
- Internal: Added `InternalProxyNotifierService` as backwards channel to notify updates from the Dataproxy to the ArunaServer
- Internal: Added `DeleteObject` and `MoveObject` requests for the `InternalProxyService` to simplify storage location migrations and properly delete objects.