### PR TITLE
Add subject to CreateStreamGroupRequest

### DIFF
--- a/aruna/api/internal/v1/notification.proto
+++ b/aruna/api/internal/v1/notification.proto
@@ -101,6 +101,8 @@ message CreateStreamGroupRequest {
     string resource_id = 4;
     // Should all "sub" resources be included
     bool notify_on_sub_resource = 5; 
+    // Subject derived from a resource hierarchy
+    string subject = 6;
 } 
 
 message CreateStreamGroupResponse {


### PR DESCRIPTION
This adds the additional field `subject`to the `CreateStreamGroupRequest`.

This request is currently used internally to persist additional stream group (Jetstream Consumer) metadata through the ArunaServer. As the subject of a stream group shall also be stored in the database, it has to be provided with the request since e.g. an Object could exist in multiple collections. So it would have to be guessed with which Collection the subject would be generated.

This PR resolves #69.