### PR TITLE
Add java-api repo to tag creation workflow

### DIFF
--- a/.github/workflows/tag-creation.yaml
+++ b/.github/workflows/tag-creation.yaml
@@ -76,3 +76,10 @@ jobs:
           repository: ArunaStorage/python-api
           event-type: publish
           client-payload: '{"version": "${{ inputs.tag }}", "message": "${{ inputs.message }}"}'
+      - name: Repository Dispatch (python)
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.ARUNA_ACCESS_TOKEN }}
+          repository: ArunaStorage/java-api
+          event-type: publish
+          client-payload: '{"version": "${{ inputs.tag }}", "message": "${{ inputs.message }}"}'

--- a/.github/workflows/tag-creation.yaml
+++ b/.github/workflows/tag-creation.yaml
@@ -76,7 +76,7 @@ jobs:
           repository: ArunaStorage/python-api
           event-type: publish
           client-payload: '{"version": "${{ inputs.tag }}", "message": "${{ inputs.message }}"}'
-      - name: Repository Dispatch (python)
+      + name: Repository Dispatch (java)
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.ARUNA_ACCESS_TOKEN }}


### PR DESCRIPTION
This adds the [ArunaStorage/java-api](https://github.com/ArunaStorage/java-api) repository to the tag creation workflow which is manually triggered after the release of a new ArunaAPI version.

The dispatch triggers the build, commit and deployment workflow in the target repository with the provided release version and description.