### PR TITLE
[feature] Cors additions / GetTokenFromSecret

### DIFF
--- a/aruna/api/internal/v1/authorize.proto
+++ b/aruna/api/internal/v1/authorize.proto
@@ -10,6 +10,7 @@ service InternalAuthorizeService {
     option (google.api.api_visibility).restriction = "INTERNAL";
     rpc Authorize(AuthorizeRequest) returns (AuthorizeResponse) {}
     rpc GetSecret(GetSecretRequest) returns (GetSecretResponse) {}
+    rpc GetTokenFromSecret(GetTokenFromSecretRequest) returns (GetTokenFromSecretResponse) {}
 }
 
 message Authorization {
@@ -53,4 +54,14 @@ message GetSecretRequest {
 message GetSecretResponse {
     Authorization authorization = 1;
 }
+
+
+message GetTokenFromSecretRequest {
+    Authorization authorization = 1;
+}
+
+message GetTokenFromSecretResponse {
+    string token = 1;
+}
+
 

--- a/aruna/api/internal/v1/proxy.proto
+++ b/aruna/api/internal/v1/proxy.proto
@@ -133,9 +133,16 @@ message GetObjectLocationRequest {
   string endpoint_id = 4;
 }
 
+message CORSConfig {
+  repeated string allowed_methods = 1;
+  repeated string allowed_origins = 2;
+  repeated string allowed_headers = 3;
+}
+
 message GetObjectLocationResponse {
   aruna.api.storage.models.v1.Object object = 1;
   Location location = 2;
+  repeated CORSConfig cors_configurations = 3;
 }
 
 message GetCollectionByBucketRequest {


### PR DESCRIPTION
# CORS support and GetTokenFromSecret to internal APIs

This small update adds CORS support to the internal GetObjectLocation request and enables the dataproxy to create short-lived api tokens on behalf of the user via s3 credentials. 
With this the dataproxy can use these tokens to modify API resources via the public API directly without the need for extra internal requests.

### Changelog

- Added `GetTokenFromSecret` rpc to internal authorize service.
- Added optional `CorsConfiguration` to `GetObjectLocationResponse` in internal proxy notifier. (https://github.com/ArunaStorage/DataProxy/issues/29)

### Breaking Changes
No breaking changes for the public API were introduced.