### PR TITLE
fix: GetObjectsAsListV2Response should return ObjectWithURL

### DIFF
--- a/aruna/api/storage/services/v1/object_service.proto
+++ b/aruna/api/storage/services/v1/object_service.proto
@@ -358,7 +358,7 @@ service ObjectService {
   //
   // Status: ALPHA
   //
-  // Gets a list of objects represented similar to a S3 ListObjectsV2 request
+  // Gets a list of ObjectWithURLs represented similar to a S3 ListObjectsV2 request
   // !! Paths are collection specific !!
   rpc GetObjectsAsListV2(GetObjectsAsListV2Request) returns (GetObjectsAsListV2Response) {
     option (google.api.http) = {
@@ -828,6 +828,7 @@ message GetObjectsAsListV2Response {
   bool is_truncated = 2;
   uint32 max_keys = 4;
   uint32 key_count = 5;
+  // Does not contain URLs, only paths
   repeated ObjectWithURL contents = 6;
   repeated CommonPrefix prefixes = 7;
   optional string next_continuation_token = 8;

--- a/aruna/api/storage/services/v1/object_service.proto
+++ b/aruna/api/storage/services/v1/object_service.proto
@@ -828,7 +828,7 @@ message GetObjectsAsListV2Response {
   bool is_truncated = 2;
   uint32 max_keys = 4;
   uint32 key_count = 5;
-  repeated storage.models.v1.Object contents = 6;
+  repeated ObjectWithURL contents = 6;
   repeated CommonPrefix prefixes = 7;
   optional string next_continuation_token = 8;
 }


### PR DESCRIPTION
This fix improves the `ListObjects` API call and reduces the number of requests needed. This is addresses Issue #82.