### PR TITLE
[feat] Update svc account handling from dev

### DIFF
--- a/aruna/api/storage/services/v1/service_account_service.proto
+++ b/aruna/api/storage/services/v1/service_account_service.proto
@@ -5,10 +5,7 @@ option go_package = "github.com/ArunaStorage/go-api/aruna/api/storage/services/v
 option java_multiple_files = true;
 option java_package = "com.github.ArunaStorage.java_api.aruna.api.storage.services.v1";
 option java_outer_classname = "ServiceAccountService";
-
 import "aruna/api/storage/models/v1/auth.proto";
-
-import "google/api/visibility.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -20,7 +17,6 @@ import "google/protobuf/timestamp.proto";
 // Service account users will always contain (bot) behind their name
 service ServiceAccountService {
 
-  option (google.api.api_visibility).restriction = "UNFINISHED";
   // CreateServiceAccount
   //
   // Creates a service account for a given project

--- a/aruna/api/storage/services/v1/service_account_service.proto
+++ b/aruna/api/storage/services/v1/service_account_service.proto
@@ -45,10 +45,10 @@ service ServiceAccountService {
     };
   }
   
-  // EditServiceAccountPermission
+  // SetServiceAccountPermission
   //
   // Overwrites the project specific permissions for a service account
-  rpc EditServiceAccountPermission(EditServiceAccountPermissionRequest) returns (EditServiceAccountPermissionResponse){
+  rpc SetServiceAccountPermission(SetServiceAccountPermissionRequest) returns (SetServiceAccountPermissionResponse){
     option (google.api.http) = {
       put : "/v1/service_account/{svc_account_id}/permissions"
       body : "*"
@@ -132,33 +132,36 @@ message CreateServiceAccountResponse {
 }
 
 message CreateServiceAccountTokenRequest {
-    // Empty if token should inherit account / project permissions
     string svc_account_id = 1;
-    // Collection id
-    string collection_id = 2;
-    // Token name
-    string name = 3;
-    // Token expiry
-    google.protobuf.Timestamp expires_at = 4;
-    // Token permissions
-    storage.models.v1.Permission permission = 5;
+    // Identify the associated project (should always be provided)
+    string project_id = 2;
+    // Collection id, will be empty if permission should be on project level
+    string collection_id = 3;
+    // (optional) Token name
+    string name = 4;
+    // (optional) Token expiry 
+    google.protobuf.Timestamp expires_at = 5;
+    // Token permissions, must be less than or equal user permissions
+    storage.models.v1.Permission permission = 6;
 }
 
 message CreateServiceAccountTokenResponse {
     // This contains only the token description
     storage.models.v1.Token token = 1;
-    // This is the actual secret token
-    // Attention, this can not be recreated and needs to be stored securely
-    // New tokens will always contain a new secret
+    // This is the actual secret API token
     string token_secret = 2;
+    // S3 Access Key
+    string s3_access_key = 3;
+    // S3 Secret Key
+    string s3_secret_key = 4;
 }
 
-message EditServiceAccountPermissionRequest {
+message SetServiceAccountPermissionRequest {
     string svc_account_id = 1;
     storage.models.v1.Permission new_permission = 2;
 }
 
-message EditServiceAccountPermissionResponse {
+message SetServiceAccountPermissionResponse {
     ServiceAccount service_account = 1;
 }
 


### PR DESCRIPTION
This PR updates the service account handling. Especially the token creation process.

## Changes

- Result token + s3 credentials similar to regular users
- Add project_id to create token request to allow for double checks for privilege escalations / correct project
- Remove UNFINISHED annotation 
- Rename EditServiceAccountPermissions to SetServiceAccountPermissions to make it clear that this overwrites the previous setting