### PR TITLE
feat: Needed changes for a minimal Hooks working example

### DIFF
--- a/aruna/api/hooks/services/v2/hooks_service.proto
+++ b/aruna/api/hooks/services/v2/hooks_service.proto
@@ -58,8 +58,9 @@ message ExternalHook {
 }
 
 enum Method {
-    METHOD_PUT = 0;
-    METHOD_POST = 1;
+    METHOD_UNSPECIFIED = 0;
+    METHOD_PUT = 1;
+    METHOD_POST = 2;
 }
 
 message AddLabel {

--- a/aruna/api/hooks/services/v2/hooks_service.proto
+++ b/aruna/api/hooks/services/v2/hooks_service.proto
@@ -103,6 +103,10 @@ message HookCallbackRequest {
     bool success = 1;
     repeated aruna.api.storage.models.v2.KeyValue add_key_values = 2;
     repeated aruna.api.storage.models.v2.KeyValue remove_key_values = 3;
+    string secret = 4;
+    string hook_id = 5;
+    string object_id = 6;
+    string pubkey_serial = 7;
 }
 
 message HookCallbackResponse{}

--- a/aruna/api/hooks/services/v2/hooks_service.proto
+++ b/aruna/api/hooks/services/v2/hooks_service.proto
@@ -56,19 +56,22 @@ message ExternalHook {
     string json_template = 3;
 }
 
-enum InternalAction {
-    INTERNAL_ACTION_UNSPECIFIED = 0;
-    INTERNAL_ACTION_ADD_LABEL = 1;
-    INTERNAL_ACTION_ADD_HOOK = 2;
-    INTERNAL_ACTION_CREATE_RELATION = 3;
+message AddLabel {
+    string key = 1;
+    string value = 2;
+}
+
+message AddHook {
+    string key = 1;
+    string value = 2;
 }
 
 message InternalHook {
-    InternalAction internal_action = 1;
-    // Either key or target ID
-    string target_id = 2;
-    // Optional value
-    string value = 3;
+    oneof internal_action {
+	AddLabel add_label = 1;
+	AddHook add_hook = 2;
+	storage.models.v2.Relation add_relation = 3;
+    }
 }
 
 message Hook {
@@ -101,8 +104,8 @@ message DeleteHookResponse {}
 
 message HookCallbackRequest {
     bool success = 1;
-    repeated aruna.api.storage.models.v2.KeyValue add_key_values = 2;
-    repeated aruna.api.storage.models.v2.KeyValue remove_key_values = 3;
+    repeated storage.models.v2.KeyValue add_key_values = 2;
+    repeated storage.models.v2.KeyValue remove_key_values = 3;
     string secret = 4;
     string hook_id = 5;
     string object_id = 6;

--- a/aruna/api/hooks/services/v2/hooks_service.proto
+++ b/aruna/api/hooks/services/v2/hooks_service.proto
@@ -54,6 +54,12 @@ message ExternalHook {
     string url = 1;
     Credentials credentials = 2;
     string json_template = 3;
+    Method method = 4;
+}
+
+enum Method {
+    METHOD_PUT = 0;
+    METHOD_POST = 1;
 }
 
 message AddLabel {

--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -17,12 +17,13 @@ enum DataClass {
 
 // Which kind of endpoint 
 enum EndpointVariant {
-  ENDPOINT_VARIANT_UNSPECIFIED = 0; ENDPOINT_VARIANT_PERSISTENT = 1;
+  ENDPOINT_VARIANT_UNSPECIFIED = 0; 
+  ENDPOINT_VARIANT_PERSISTENT = 1;
   ENDPOINT_VARIANT_VOLATILE = 2;
 }
 
 // Which features does the endpoint have
-enum EndpointHostType {
+enum EndpointHostVariant {
   ENDPOINT_HOST_TYPE_UNSPECIFIED = 0;
   ENDPOINT_HOST_TYPE_GRPC= 1;
   ENDPOINT_HOST_TYPE_S3= 2;
@@ -324,7 +325,7 @@ message Dataset {
 }
 
 message Object {
-  string id = 1;                    
+  string id = 1;
   string name = 2;
   string description = 3;
   // Collection specific labels / hooks
@@ -339,10 +340,5 @@ message Object {
   bool dynamic = 11;
   repeated DataEndpoint endpoints = 12;
   // Object specific attributes
-<<<<<<< Updated upstream
   repeated Hash hashes = 13;  
 }
-=======
-  repeated Hash hashes = 12;  
-}
->>>>>>> Stashed changes

--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -17,16 +17,15 @@ enum DataClass {
 
 // Which kind of endpoint 
 enum EndpointVariant {
-  ENDPOINT_VARIANT_UNSPECIFIED = 0;
-  ENDPOINT_VARIANT_PERSISTENT = 1;
+  ENDPOINT_VARIANT_UNSPECIFIED = 0; ENDPOINT_VARIANT_PERSISTENT = 1;
   ENDPOINT_VARIANT_VOLATILE = 2;
 }
 
 // Which features does the endpoint have
-enum EndpointHostVariant {
-  ENDPOINT_HOST_VARIANT_UNSPECIFIED = 0;
-  ENDPOINT_HOST_VARIANT_PROXY = 1;
-  ENDPOINT_HOST_VARIANT_BUNDLER = 2;
+enum EndpointHostType {
+  ENDPOINT_HOST_TYPE_UNSPECIFIED = 0;
+  ENDPOINT_HOST_TYPE_GRPC= 1;
+  ENDPOINT_HOST_TYPE_S3= 2;
 }
 
 // Permission Levels
@@ -340,5 +339,10 @@ message Object {
   bool dynamic = 11;
   repeated DataEndpoint endpoints = 12;
   // Object specific attributes
+<<<<<<< Updated upstream
   repeated Hash hashes = 13;  
 }
+=======
+  repeated Hash hashes = 12;  
+}
+>>>>>>> Stashed changes

--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -24,9 +24,9 @@ enum EndpointVariant {
 
 // Which features does the endpoint have
 enum EndpointHostVariant {
-  ENDPOINT_HOST_TYPE_UNSPECIFIED = 0;
-  ENDPOINT_HOST_TYPE_GRPC= 1;
-  ENDPOINT_HOST_TYPE_S3= 2;
+  ENDPOINT_HOST_VARIANT_UNSPECIFIED = 0;
+  ENDPOINT_HOST_VARIANT_GRPC= 1;
+  ENDPOINT_HOST_VARIANT_S3= 2;
 }
 
 // Permission Levels

--- a/aruna/api/storage/services/v2/search_service.proto
+++ b/aruna/api/storage/services/v2/search_service.proto
@@ -58,5 +58,5 @@ message GetResourceRequest {
 
 message GetResourceResponse {
   storage.models.v2.GenericResource resource = 1;
-  storage.models.v2.PermissionLevel permisson = 2;
+  storage.models.v2.PermissionLevel permission = 2;
 }

--- a/aruna/api/storage/services/v2/search_service.proto
+++ b/aruna/api/storage/services/v2/search_service.proto
@@ -27,9 +27,9 @@ service SearchService {
     // Status: BETA
     //
     // Retrieves a public resource by its ID.
-    rpc GetPublicResource(GetPublicResourceRequest) returns (GetPublicResourceResponse){
+    rpc GetResource(GetResourceRequest) returns (GetResourceResponse){
       option (google.api.http) = {
-        get : "/v2/public/{resource_id}"
+        get : "/v2/resource/{resource_id}"
       };
     }
 
@@ -52,10 +52,11 @@ message SearchResourcesResponse {
     int64 last_index = 3;
 }
 
-message GetPublicResourceRequest {
+message GetResourceRequest {
   string resource_id = 1;
 }
 
-message GetPublicResourceResponse {
-  storage.models.v2.GenericResource resources = 1;
+message GetResourceResponse {
+  storage.models.v2.GenericResource resource = 1;
+  storage.models.v2.PermissionLevel permisson = 2;
 }


### PR DESCRIPTION
These are very basic changes needed for a minimal working example for hooks.
# Hooks
- `HookCallbackRequest` now contain a `secret`, `hook_id`, `object_id` and `pubkey_serial` field.
# Endpoints
- `EndpointHostType` are changed to `GRPC` and `S3` fields.