### PR TITLE
[2.0.0 beta.8] Multi-oidc support

### DIFF
--- a/aruna/api/dataproxy/services/v2/bundler_service.proto
+++ b/aruna/api/dataproxy/services/v2/bundler_service.proto
@@ -29,7 +29,7 @@ service BundlerService {
 
 
 message CreateBundleRequest {
-    repeated string resource_id = 1;
+    repeated string resource_ids = 1;
     string filename = 2; // .tar.gz / .zip
     google.protobuf.Timestamp expires_at = 3; // Default 1 Month
 }

--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -122,10 +122,9 @@ enum ResourceVariant {
 
 // ------------- USERS & PERMISSIONS -----------------------
 message User {
+  reserved 2;
   // Internal Aruna UserID
   string id = 1;
-  // Oidc subject ID
-  string external_id = 2;
   // (optional) User display_name
   string display_name = 3;
   // Is the user activated
@@ -166,6 +165,11 @@ message CustomAttributes {
   string attribute_value = 2;
 }
 
+message OidcMapping {
+  string external_id = 1;
+  string oidc_url = 2;
+}
+
 message UserAttributes {
   bool global_admin = 1;
   bool service_account = 2;
@@ -173,6 +177,7 @@ message UserAttributes {
   repeated string trusted_endpoints = 4;
   repeated CustomAttributes custom_attributes = 5; 
   repeated Permission personal_permissions = 6;
+  repeated OidcMapping external_ids = 7;
 }
 
 // --------------- RELATION / KEYVALUES -------------------

--- a/aruna/api/storage/services/v2/user_service.proto
+++ b/aruna/api/storage/services/v2/user_service.proto
@@ -235,6 +235,20 @@ service UserService {
     };
   }
 
+  rpc AddOidcProvier(AddOidcProviderRequest) returns (AddOidcProviderResponse) {
+    option (google.api.http) = {
+      patch : "/v2/user/add_oidc"
+      body : "*"
+    };
+  }
+
+  rpc RemoveOidcProvider(RemoveOidcProviderRequest) returns (RemoveOidcProviderResponse) {
+    option (google.api.http) = {
+      patch : "/v2/user/remove_oidc"
+      body : "*"
+    };
+  }
+
 }
 
 message RegisterUserRequest {
@@ -433,4 +447,20 @@ message PersonalNotification {
   PersonalNotificationVariant variant = 2;
   string message = 3; // User A has requested access for resource B
   repeated Reference refs = 4; // References to resource in the "message"
+}
+
+message AddOidcProviderRequest {
+  string new_access_token = 1;
+}
+
+message AddOidcProviderResponse {
+  storage.models.v2.User user = 1;
+}
+
+message RemoveOidcProviderRequest {
+  string provider_url = 1;
+}
+
+message RemoveOidcProviderResponse {
+  storage.models.v2.User user = 1;
 }


### PR DESCRIPTION
This PR adds the ability to add more than one external identity provider.

## Changes
- Remove external_id from user to user_attributes 
- Created an OIDCMapping message that combines an external id with a corresponding oidc provider
- Added functions to Add or remove other OIDC provider to an existing account#
- (typo) rename repeated `resource_id` to `resource_ids` in bundler
